### PR TITLE
Turn state management

### DIFF
--- a/Assets/Scenes/Tests/_test_CreateRoom.unity
+++ b/Assets/Scenes/Tests/_test_CreateRoom.unity
@@ -41,7 +41,7 @@ RenderSettings:
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 6
-  m_GIWorkflowMode: 1
+  m_GIWorkflowMode: 0
   m_LightmapsMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -85,121 +85,134 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualCellSize: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &100821664
+--- !u!1 &1132827782
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 100821666}
-  - 108: {fileID: 100821665}
+  - 4: {fileID: 1132827786}
+  - 33: {fileID: 1132827785}
+  - 135: {fileID: 1132827784}
+  - 23: {fileID: 1132827783}
   m_Layer: 0
-  m_Name: Directional Light
+  m_Name: Sphere
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!108 &100821665
-Light:
+--- !u!23 &1132827783
+MeshRenderer:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 100821664}
+  m_GameObject: {fileID: 1132827782}
   m_Enabled: 1
-  serializedVersion: 6
-  m_Type: 1
-  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
-  m_Intensity: 1
-  m_Range: 10
-  m_SpotAngle: 30
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 2
-    m_Resolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_Lightmapping: 4
-  m_BounceIntensity: 1
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
-  m_AreaSize: {x: 1, y: 1}
---- !u!4 &100821666
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 1
+  m_ReflectionProbeUsage: 1
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!135 &1132827784
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1132827782}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &1132827785
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1132827782}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1132827786
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 100821664}
-  m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_GameObject: {fileID: 1132827782}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 5, z: 5}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
---- !u!1001 &439798950
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 479604, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 4120c3c00a66648ecaeb008d4cb01e3e, type: 2}
-  m_IsPrefabParent: 0
---- !u!1 &885620637
+  m_RootOrder: 3
+--- !u!1 &1195488038
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
-  - 4: {fileID: 885620642}
-  - 20: {fileID: 885620641}
-  - 92: {fileID: 885620640}
-  - 124: {fileID: 885620639}
-  - 81: {fileID: 885620638}
+  - 4: {fileID: 1195488039}
+  - 114: {fileID: 1195488040}
+  m_Layer: 0
+  m_Name: __manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1195488039
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1195488038}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -9.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &1195488040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1195488038}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c577024f7e6e344b3b4fb7e62fcf4dbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneIndex: 1
+  minimumPlayers: 2
+--- !u!1 &1733894533
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1733894538}
+  - 20: {fileID: 1733894537}
+  - 92: {fileID: 1733894536}
+  - 124: {fileID: 1733894535}
+  - 81: {fileID: 1733894534}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -207,33 +220,33 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &885620638
+--- !u!81 &1733894534
 AudioListener:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 885620637}
+  m_GameObject: {fileID: 1733894533}
   m_Enabled: 1
---- !u!124 &885620639
+--- !u!124 &1733894535
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 885620637}
+  m_GameObject: {fileID: 1733894533}
   m_Enabled: 1
---- !u!92 &885620640
+--- !u!92 &1733894536
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 885620637}
+  m_GameObject: {fileID: 1733894533}
   m_Enabled: 1
---- !u!20 &885620641
+--- !u!20 &1733894537
 Camera:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 885620637}
+  m_GameObject: {fileID: 1733894533}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
@@ -262,15 +275,76 @@ Camera:
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
   m_StereoMirrorMode: 0
---- !u!4 &885620642
+--- !u!4 &1733894538
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 885620637}
+  m_GameObject: {fileID: 1733894533}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
+--- !u!1 &1846816034
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1846816036}
+  - 108: {fileID: 1846816035}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1846816035
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1846816034}
+  m_Enabled: 1
+  serializedVersion: 6
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_BounceIntensity: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_AreaSize: {x: 1, y: 1}
+--- !u!4 &1846816036
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1846816034}
+  m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2

--- a/Assets/Scenes/Tests/_test_CreateRoom.unity.meta
+++ b/Assets/Scenes/Tests/_test_CreateRoom.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1302fa3f1e0b84f85ab3318a407de696
+timeCreated: 1461929219
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Tests/_test_TurnManagement.unity
+++ b/Assets/Scenes/Tests/_test_TurnManagement.unity
@@ -1,0 +1,436 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+SceneSettings:
+  m_ObjectHideFlags: 0
+  m_PVSData: 
+  m_PVSObjectsArray: []
+  m_PVSPortalsArray: []
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_GIWorkflowMode: 1
+  m_LightmapsMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 3
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AOMaxDistance: 1
+    m_Padding: 2
+    m_CompAOExponent: 0
+    m_LightmapParameters: {fileID: 0}
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherRayCount: 1024
+    m_ReflectionCompression: 2
+  m_LightingDataAsset: {fileID: 0}
+  m_RuntimeCPUUsage: 25
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    accuratePlacement: 0
+    minRegionArea: 2
+    cellSize: 0.16666667
+    manualCellSize: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &118293537
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 118293541}
+  - 33: {fileID: 118293540}
+  - 65: {fileID: 118293539}
+  - 23: {fileID: 118293538}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &118293538
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 118293537}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 1
+  m_ReflectionProbeUsage: 1
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!65 &118293539
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 118293537}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &118293540
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 118293537}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &118293541
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 118293537}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.2, y: 0, z: 14}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+--- !u!1 &1144651927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1144651928}
+  - 114: {fileID: 1144651929}
+  - 114: {fileID: 1144651930}
+  m_Layer: 0
+  m_Name: __manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1144651928
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1144651927}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -9.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &1144651929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1144651927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ab4a08993d4c48c2ae3a449e704fc57, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  forceMasterImplementation: 0
+--- !u!114 &1144651930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1144651927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14cef48a6be3e4d92841fffdb9d8912e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1400148764
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1400148766}
+  - 108: {fileID: 1400148765}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1400148765
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1400148764}
+  m_Enabled: 1
+  serializedVersion: 6
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_BounceIntensity: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_AreaSize: {x: 1, y: 1}
+--- !u!4 &1400148766
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1400148764}
+  m_LocalRotation: {x: 0.2588314, y: -0.21340968, z: 0.1464365, w: 0.9306015}
+  m_LocalPosition: {x: 0, y: 3, z: -5.3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+--- !u!1 &1407147213
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 1407147218}
+  - 20: {fileID: 1407147217}
+  - 92: {fileID: 1407147216}
+  - 124: {fileID: 1407147215}
+  - 81: {fileID: 1407147214}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1407147214
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1407147213}
+  m_Enabled: 1
+--- !u!124 &1407147215
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1407147213}
+  m_Enabled: 1
+--- !u!92 &1407147216
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1407147213}
+  m_Enabled: 1
+--- !u!20 &1407147217
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1407147213}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0.019607844}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!4 &1407147218
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1407147213}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+--- !u!1 &2037019199
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 2037019203}
+  - 33: {fileID: 2037019202}
+  - 65: {fileID: 2037019201}
+  - 23: {fileID: 2037019200}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &2037019200
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2037019199}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 1
+  m_ReflectionProbeUsage: 1
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!65 &2037019201
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2037019199}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &2037019202
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2037019199}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2037019203
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2037019199}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.6, y: 0, z: 14}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4

--- a/Assets/Scenes/Tests/_test_TurnManagement.unity.meta
+++ b/Assets/Scenes/Tests/_test_TurnManagement.unity.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 7460e5bb74f064c02ac6659967ca8552
-timeCreated: 1461164752
+guid: 0b7be726fd9bd4bf7ac40b587e984b49
+timeCreated: 1461929616
 licenseType: Free
 DefaultImporter:
   userData: 

--- a/Assets/Scripts/Custom/Game/States.cs
+++ b/Assets/Scripts/Custom/Game/States.cs
@@ -16,6 +16,20 @@ namespace TowerVR
 			return potentialGameState >= AwaitingPlayers && 
 				   potentialGameState <= Stopped;
 		}
+		
+		public static string ToString(int gameState)
+		{
+			switch (gameState)
+			{
+				case AwaitingPlayers: return "AwaitingPlayers";
+				case AllPlayersReady: return "AllPlayersReady";
+				case Countdown: return "Countdown";
+				case Running: return "Running";
+				case Ended: return "Ended";
+				case Stopped: return "Stopped";
+				default: return "<INVALID_GAMESTATE>";
+			}
+		}
 	}
 
 	public class TurnState
@@ -29,6 +43,18 @@ namespace TowerVR
 		{
 			return potentialTurnState >= NotStarted && 
 				   potentialTurnState <= TowerReacting;
+		}
+		
+		public static string ToString(int turnState)
+		{
+			switch (turnState)
+			{
+				case NotStarted: return "NotStarted";
+				case SelectingTowerPiece: return "SelectingTowerPiece";
+				case PlacingTowerPiece: return "PlacingTowerPiece";
+				case TowerReacting: return "TowerReacting";
+				default: return "<INVALID_TURNSTATE>";
+			}
 		}
 	}
 }

--- a/Assets/Scripts/Custom/Game/Tower/Manager/Impl/TowerGameManagerImpl.cs
+++ b/Assets/Scripts/Custom/Game/Tower/Manager/Impl/TowerGameManagerImpl.cs
@@ -228,14 +228,19 @@ namespace TowerVR
 		
 		protected static void LogMalformedEventContent(string eventName, int senderID)
 		{
-			Debug.LogError("Received " + eventName + " with malformed event content from playerID=" + senderID + ".");
+			Error("Received " + eventName + " with malformed event content from playerID=" + senderID + ".");
 		}
 		
 		#endregion PRIVATE_MEMBER_VARIABLES
 		
 		private static void Log(object obj)
         {
-            Debug.Log(obj.ToString());
+            Debug.Log("TowerGameManagerImpl: " + obj.ToString());
+        }
+		
+        private static void Error(object obj)
+        {
+            Debug.LogError("MasterTowerGameManagerImpl: " + obj.ToString());
         }
 
 	}

--- a/Assets/Scripts/Custom/Game/Tower/Manager/TowerGameManager.cs
+++ b/Assets/Scripts/Custom/Game/Tower/Manager/TowerGameManager.cs
@@ -13,6 +13,8 @@ namespace TowerVR
 	 **/
 	public sealed class TowerGameManager : Singleton<TowerGameManager>, ITowerGameManager
 	{		
+		public bool TEST_forceMasterImplementation = false;
+		
 		#region PUBLIC_MEMBER_FUNCTIONS
 		
 		/// See ITowerGameManager
@@ -73,7 +75,7 @@ namespace TowerVR
 		void Awake()
 		{	
 			// Instantiate an implementation of the correct type
-			if (PhotonNetwork.isMasterClient)
+			if (PhotonNetwork.isMasterClient || TEST_forceMasterImplementation)
 			{
 				Debug.Log("Player is master client, instantiating MasterTowerGameManagerImpl");
 				impl = gameObject.AddComponent<MasterTowerGameManagerImpl>();

--- a/Assets/Scripts/Custom/Game/Tower/MasterClientOnlyBehaviour.cs
+++ b/Assets/Scripts/Custom/Game/Tower/MasterClientOnlyBehaviour.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using System.Collections;
+
+namespace TowerVR
+{
+    /**
+     * Base Behaviour class that only runs on the PhotonNetwork master client.
+     * */
+    public abstract class MasterClientOnlyBehaviour : TowerGameBehaviour
+    {
+        void Awake()
+        {
+            if (!PhotonNetwork.isMasterClient)
+            {
+                Destroy(this);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Custom/Game/Tower/MasterClientOnlyBehaviour.cs.meta
+++ b/Assets/Scripts/Custom/Game/Tower/MasterClientOnlyBehaviour.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c121ed0b3dbbe408da03228933aec385
+timeCreated: 1461922008
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Custom/Game/Tower/TowerGameBehaviour.cs
+++ b/Assets/Scripts/Custom/Game/Tower/TowerGameBehaviour.cs
@@ -8,7 +8,7 @@ namespace TowerVR
     * 
     * Refer to the TowerGameManager's "DELEGATES"-documentation to see usage.
     * */
-    public class TowerGameBehaviour : MonoBehaviour
+    public abstract class TowerGameBehaviour : MonoBehaviour
     {
         /**
          * Exposed property that retrieves the scene's TowerGameManager singleton instance.

--- a/Assets/Scripts/Custom/Game/TowerGameConstants.cs
+++ b/Assets/Scripts/Custom/Game/TowerGameConstants.cs
@@ -2,9 +2,9 @@ namespace TowerVR
 {
     public class TurnTimeLimits
     {
-        public const float SelectingTowerPiece = 10.0f;
-        public const float PlacingTowerPiece = 20.0f;
-        public const float TowerReacting = 30.0f;
+        public const float SelectingTowerPiece = 2.0f;
+        public const float PlacingTowerPiece = 3.0f;
+        public const float TowerReacting = 5.0f;
         
         // No instantiation of class
         private TurnTimeLimits() {}

--- a/Assets/Scripts/Custom/Game/TowerGameConstants.cs
+++ b/Assets/Scripts/Custom/Game/TowerGameConstants.cs
@@ -1,0 +1,12 @@
+namespace TowerVR
+{
+    public class TurnTimeLimits
+    {
+        public const float SelectingTowerPiece = 10.0f;
+        public const float PlacingTowerPiece = 20.0f;
+        public const float TowerReacting = 30.0f;
+        
+        // No instantiation of class
+        private TurnTimeLimits() {}
+    }
+}

--- a/Assets/Scripts/Custom/Game/TowerGameConstants.cs.meta
+++ b/Assets/Scripts/Custom/Game/TowerGameConstants.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a40cd2338e8d046548bf509dc695cb9f
+timeCreated: 1461767118
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Custom/Game/_test/ConnectAndCreateTowerManager.cs
+++ b/Assets/Scripts/Custom/Game/_test/ConnectAndCreateTowerManager.cs
@@ -19,6 +19,5 @@ public class ConnectAndCreateTowerManager : MonoBehaviour
 		Debug.Log("OnJoinedRoom");
 		
 		gameObject.AddComponent<TowerVR.TowerGameManager>();
-		gameObject.AddComponent<TowerVR.PlayerTurnObserver>();
 	}
 }

--- a/Assets/Scripts/Custom/Game/_test/ConnectAndJoinTest.cs
+++ b/Assets/Scripts/Custom/Game/_test/ConnectAndJoinTest.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+using System.Collections;
+using UnityEngine.SceneManagement;
+
+public class ConnectAndJoinTest : MonoBehaviour {
+	public int sceneIndex;
+	public int minimumPlayers = 1;
+	
+	void Start () {
+		Debug.Log("Start");
+		PhotonNetwork.ConnectUsingSettings("1.0");
+	}
+	
+	void OnConnectedToMaster()
+	{
+		Debug.Log("OnConnectedToMaster");
+		PhotonNetwork.JoinOrCreateRoom("SwagBOI", new RoomOptions(), new TypedLobby());
+	}
+	
+	void Update()
+	{
+		if (PhotonNetwork.playerList.Length >= minimumPlayers)
+		{
+			SceneManager.LoadScene(sceneIndex);
+		}
+	}
+}

--- a/Assets/Scripts/Custom/Game/_test/ConnectAndJoinTest.cs.meta
+++ b/Assets/Scripts/Custom/Game/_test/ConnectAndJoinTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c577024f7e6e344b3b4fb7e62fcf4dbb
+timeCreated: 1461930768
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Custom/Game/_test/MasterStartGame.cs
+++ b/Assets/Scripts/Custom/Game/_test/MasterStartGame.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+using System.Collections;
+
+namespace TowerVR
+{
+    public class MasterStartGame : MasterClientOnlyBehaviour
+    {
+        private bool canStartGame = false;
+        
+        void onGameStateChanged(int gameState)
+        {
+            Log("onGameStateChanged [gameState=" + gameState + "]");
+            
+            canStartGame = true;
+        }
+        
+        void Start()
+        {
+            manager.gameStateChangedHandlers.Add(onGameStateChanged);
+        }
+        
+        void Update()
+        {
+            if (canStartGame && Input.anyKeyDown)
+            {
+                Log("Start game");
+            }
+        }
+        
+        void OnGUI()
+        {
+            if (canStartGame)
+            {
+                GUILayout.Label("You can now start the game!");
+            }
+        }
+        
+        private static void Log(object obj)
+        {
+            Debug.Log("MasterStartGame" + obj.ToString());
+        }
+    }
+}

--- a/Assets/Scripts/Custom/Game/_test/MasterStartGame.cs.meta
+++ b/Assets/Scripts/Custom/Game/_test/MasterStartGame.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 35078898c10c34754b03cb105998e0cc
+timeCreated: 1461922803
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Custom/Generic/Timer.cs
+++ b/Assets/Scripts/Custom/Generic/Timer.cs
@@ -1,0 +1,64 @@
+﻿using UnityEngine;
+using System.Collections;
+
+/**
+ * Simple timer class. Is a Unity component that automatically updates its internal timer.
+ **/
+public class Timer : MonoBehaviour 
+{
+	/**
+     * The timer's value, in seconds.
+     **/
+    public double time
+    { get; private set; }
+	
+    private bool isActive;
+
+	// Use this for initialization
+	void Start () 
+	{
+		isActive = false;
+        time = 0.0;
+	}
+	
+	// Update is called once per frame
+	void Update () 
+	{
+		if (isActive)
+        {
+            time += Time.deltaTime; 
+        }
+	}
+	
+	
+    /**
+     * Start the timer. Returns its current timer count.
+     **/
+    public double start()
+    {
+        isActive = true;
+        return time;
+    }
+    
+    /**
+     * Stops the timer. Returns its current timer count.
+     **/
+    public double stop()
+    {
+        isActive = false;
+        return time;
+    }
+    
+    /**
+     * Clears the timer. Returns the timer count before setting it to zero.
+     **/
+    public double clear()
+    {
+        stop();
+        
+        var prev = time;
+        time = 0.0;
+        
+        return prev;
+    }
+}

--- a/Assets/Scripts/Custom/Generic/Timer.cs.meta
+++ b/Assets/Scripts/Custom/Generic/Timer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 11178edf0e8184d60b01303bb87c492c
+timeCreated: 1461935992
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implemented proper turn state handling with time limits when selecting difficulty, placing the tower piece and when the tower "reacts". It works for 2+ players currently, cycling through the players in order.

Additionally, cleaned up the turn state and game state properties so the "syncTurn/GameState" methods are unneccessary, now it auto-syncs when the properties are set:
turnState = TurnState.TowerReacting; // turnState is set and synced to all clients
